### PR TITLE
modules: Fix devicesettings path for doze

### DIFF
--- a/modules/doze/Android.mk
+++ b/modules/doze/Android.mk
@@ -19,7 +19,7 @@ LOCAL_STATIC_JAVA_LIBRARIES := \
 
 LOCAL_RESOURCE_DIR := \
     $(LOCAL_PATH)/res \
-    $(LOCAL_PATH)/../../../../packages/resources/devicesettings/res \
+    packages/resources/devicesettings/res \
     frameworks/support/v7/preference/res \
     frameworks/support/v14/preference/res \
     frameworks/support/v7/appcompat/res \


### PR DESCRIPTION
* Was broken when moved to modules, since it iss a relative path

Change-Id: I7d934e7cfeccdc4bcaaf917de1316e81b34ae220